### PR TITLE
Run all SPI tests. handle no devices found.

### DIFF
--- a/401DigiLabApp/scenes/spi/401DigiLab_spitool_scanner.c
+++ b/401DigiLabApp/scenes/spi/401DigiLab_spitool_scanner.c
@@ -165,12 +165,9 @@ static bool spitoolscanner_tests(cJSON* json_device) {
         } else {
             return false;
         }
-
-        if(res) {
-            return true;
-        }
     }
-    return false;
+
+    return res;
 }
 
 static void spitoolscanner_powercycle() {
@@ -273,7 +270,7 @@ static bool spitoolscanner_scan(AppSPIToolScanner* appSpitoolScanner) {
     with_view_model(
         appSpitoolScanner->view,
         SPIToolScannerModel * model,
-        { model->screenview = SPI_VIEW_DETAIL; },
+        { model->screenview = model->devices ? SPI_VIEW_DETAIL : SPI_VIEW_UNKNOWN; },
         true);
     return true;
 }


### PR DESCRIPTION
When scanning for SPI devices, run all tests in the set (until one fails) before returning the result.
If no SPI devices are detected, return the SPI_VIEW_UNKNOWN to show error message.